### PR TITLE
Bump pax logging version to clear log4shell vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		<dependency>
 		<groupId>org.ops4j.pax.logging</groupId>
 			<artifactId>pax-logging-api</artifactId>
-			<version>1.5.2</version>
+			<version>1.11.11</version>
 		</dependency>
 
 		<!-- Cytoscape API Dependencies -->


### PR DESCRIPTION
Please consider this PR as soon as possible and upload a new version or your app to the Cytoscape App Store.
https://apps.cytoscape.org/apps/cyrface